### PR TITLE
Fix: wrong value 'True' for param num_pca_comps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *__pycache__/
 *DS_Store
+
+# resulted dataset
+data/
+models/

--- a/process/canonicalize_human_multi_thread.py
+++ b/process/canonicalize_human_multi_thread.py
@@ -241,7 +241,7 @@ def process_sequence(dataset, name, MOTION_PATH, dataset_path, NEW_MOTION_PATH, 
             verts, faces, joints = visualize_smpl(name, MOTION_PATH, 'smplx', 10)
             markers = verts[:,markerset_smplx]
         elif dataset.upper() == 'INTERCAP':
-            verts, faces, joints = visualize_smpl(name, MOTION_PATH, 'smplx', 10, True)
+            verts, faces, joints = visualize_smpl(name, MOTION_PATH, 'smplx', 10, 12)
             markers = verts[:,markerset_smplx]
         elif dataset.upper() == 'OMOMO':
             verts, faces, joints = visualize_smpl(name, MOTION_PATH, 'smplx', 16)

--- a/process/process_bps.py
+++ b/process/process_bps.py
@@ -23,6 +23,8 @@ if __name__ == "__main__":
         MOTION_PATH = os.path.join(dataset_path, 'sequences_canonical')
         OBJECT_PATH = os.path.join(dataset_path, 'objects')
         OBJECT_BPS_PATH = os.path.join(dataset_path, 'objects_bps')
+        
+        os.makedirs(OBJECT_BPS_PATH, exist_ok=True)  # create folder if not exist
         data_name = os.listdir(OBJECT_PATH)
         for k, name in tqdm(enumerate(data_name)):
             mesh_obj = trimesh.load(os.path.join(OBJECT_PATH, f"{name}/{name}.obj"), force='mesh')


### PR DESCRIPTION
fix: wrong value 'True' for param num_pca_comps

> Processing intercap:   0%|          | 0/168 [00:00<?, ?it/s]
> shape '[-1, 15, 3]' is invalid for input of size 3120
> Sub10_Object04_Seg_1_umbrella_0
> shape '[-1, 15, 3]' is invalid for input of size 2448
> Sub05_Object09_Seg_1_cup_268
> shape '[-1, 15, 3]' is invalid for input of size 4800
> Sub07_Object07_Seg_1_chair_0
> shape '[-1, 15, 3]' is invalid for input of size 5280
> Sub02_Object09_Seg_1_cup_0
> shape '[-1, 15, 3]' is invalid for input of size 8160
> Sub07_Object07_Seg_0_chair_0
> shape '[-1, 15, 3]' is invalid for input of size 6192
> Sub05_Object09_Seg_1_cup_0
> shape '[-1, 15, 3]' is invalid for input of size 2712
> Sub07_Object05_Seg_0_racket_0
> Sizes of tensors must match except in dimension 1. Expected size 150 but got size 80 for tensor number 5 in the list.
> Sub09_Object04_Seg_0_umbrella_0

chore: add data/ and models/ to .gitignore
chore: create OBJECT_BPS_PATH if not exist in process_bps.py